### PR TITLE
Fix typo: 'p7zip'

### DIFF
--- a/ML_regression_kaggle_product_sales_v3.ipynb
+++ b/ML_regression_kaggle_product_sales_v3.ipynb
@@ -112,7 +112,7 @@
     "###Now go to the terminal and unzip all the files from command line using following commands\n",
     "#1. Install 7zip on amazon linux\n",
     "#yum-config-manager --enable epel\n",
-    "#yum install -y p7ip\n",
+    "#yum install -y p7zip\n",
     "#cp /usr/bin/7za /usr/bin/7z\n",
     "#7z\n",
     "\n",


### PR DESCRIPTION
Fix typo in shell code example (doesn't directly affect the Python code)
